### PR TITLE
Line break fix

### DIFF
--- a/yts/cssbin/styles.css
+++ b/yts/cssbin/styles.css
@@ -453,6 +453,8 @@ a.title:hover {
     padding-bottom: 5px;
     color: #000;
     border-bottom: 1px dashed #CCC;
+    /* fix for line breaks in youtubei response */
+    white-space: pre-line;
 }
 
 .watchTags {


### PR DESCRIPTION
Fix `watch.php` descriptions `\n` not working properly. Rather easy 1-line css fix.