### PR TITLE
fix player getting requests blocked by yt

### DIFF
--- a/includes/config.inc.php
+++ b/includes/config.inc.php
@@ -3,7 +3,9 @@
 $resultsCount = 10; // how many results you want in the search page
 
 /* INNERTUBE REQUESTS SPECIFIC STUFF */
-define("ANDROIDTUBE_REQUEST_CLIENT_VERSION",  "16.12.11"); // only used in player
+define("ANDROIDTUBE_REQUEST_CLIENT_VERSION",  "17.31.35"); // only used in player
+define("ANDROIDTUBE_REQUEST_USER_AGENT", "com.google.android.youtube/17.31.35 (Linux; U; Android 11) gzip");
+define("ANDROIDTUBE_SDK_VERSION", 30);
 
 define("INNERTUBE_CONTEXT_CLIENT_VERSION", "2.20220629.00.01");
 

--- a/includes/youtubei/player.php
+++ b/includes/youtubei/player.php
@@ -64,6 +64,7 @@ function requestVideoSrc($videoId)
                     'hl' => 'en',
                     'clientName' => 'ANDROID',
                     'clientVersion' => ANDROIDTUBE_REQUEST_CLIENT_VERSION,
+                    'androidSdkVersion' => ANDROIDTUBE_SDK_VERSION,
                     'mainAppWebInfo' =>
                     array(
                         'graftUrl' => '/watch?v=' . $videoId,
@@ -81,7 +82,7 @@ function requestVideoSrc($videoId)
         "X-Origin: https://www.youtube.com",
     ));
     curl_setopt($ch, CURLOPT_POSTFIELDS, $req_arr);
-    curl_setopt($ch, CURLOPT_USERAGENT, INNERTUBE_REQUEST_USER_AGENT);
+    curl_setopt($ch, CURLOPT_USERAGENT, ANDROIDTUBE_REQUEST_USER_AGENT);
     curl_setopt($ch, CURLOPT_POST, true);
     curl_setopt($ch, CURLOPT_URL, "https://www.youtube.com/youtubei/v1/player?key=" . INNERTUBE_REQUEST_API_KEY);
 


### PR DESCRIPTION
The part where it sends a request as an Android client was giving back a response with some support link telling you to update the app or stop using scrapers. I checked how [yt-dlp](https://github.com/yt-dlp/yt-dlp/blob/master/yt_dlp/extractor/youtube.py) was doing it, and updated the user agent and stuff to match. The player works correctly now.